### PR TITLE
fix: waitandClickByText and importAccountFromPrivateKey

### DIFF
--- a/support/metamask.js
+++ b/support/metamask.js
@@ -45,16 +45,16 @@ module.exports = {
 
   async importMetaMaskWalletUsingPrivateKey(key) {
     // interact with the MM extension
-    console.log('In Metamask.js:' + key)
-
     await puppeteer.waitAndClick(mainPageElements.accountMenu.button);
-    await puppeteer.waitAndClickByText('.account-menu__item__text', 'Import Account')
-    console.log('Clicked on Import Account')
-    // await puppeteer.waitAndClick(mainPageElements.accountMenu.importAccount); 
-    // await puppeteer.waitAndType('#private-key-box', key)
-    await puppeteer.waitAndClick('.new-account-create-form__button')
-    return true
-  },
+    await puppeteer.waitAndClickByText('.account-menu__item__text', 'Import Account');
+    console.log('Clicked on Import Account');
+    await puppeteer.waitAndType('#private-key-box', key);
+    await puppeteer.waitAndClick('.new-account-create-form__button');
+    await puppeteer.waitAndClick(mainPageElements.accountMenu.importAccount);
+    await puppeteer.metamaskWindow().waitForTimeout(2000);
+
+    return true;
+},
 
   async confirmWelcomePage() {
     await module.exports.fixBlankPage();

--- a/support/puppeteer.js
+++ b/support/puppeteer.js
@@ -97,29 +97,18 @@ module.exports = {
 
   async waitAndClickByText(selector, elementText, page = metamaskWindow) {
     await module.exports.waitFor(selector, page);
-    console.log("Selector: " + selector)
-    console.log("Text: " + elementText)
-    await page.evaluate(async () => {
-      console.log('Waiting')
-      // await page.waitForTimeout(1000);
-      console.log('Done waiting')
-      console.log(document.querySelectorAll('.account-menu__item__text'))
-
-      const selectors = document.querySelectorAll('.account-menu__item__text')
-      const importNode = Array.from(selectors).find(selector => selector.innerText === "Import Account")
-      importNode.click()
-
-      // console.log("My selector " + selector)
-      // const selectors = [...document.querySelectorAll(selector)]
-      // console.table("What The Fox??? " + selectors)
-      // return selectors
-      //   .find(element => {
-      //     console.log(element.textContent)
-      //     element.textContent === elementText
-      //   })
-      //   .click();
-    });
+    await page.evaluate(
+      ({ elementText, selector }) => {
+        const selectors = document.querySelectorAll(selector);
+        const importNode = Array.from(selectors).find(
+          (selector) => selector.innerText === elementText
+        );
+        importNode.click();
+      },
+      { elementText, selector }
+    );
   },
+  
   async waitAndType(selector, value, page = metamaskWindow) {
     await module.exports.waitFor(selector, page);
     const element = await page.$(selector);


### PR DESCRIPTION
turns out that page.evaluate takes two arguments the first one is a callback (selector) => selector.doSomething the second one is selector it self so the implementation should always be like this 

`doSomething = (selector) => {
page.evaluate((selector) => selector.doSomething() , selector)
}`

