### PR TITLE
Add task to reset state between runs

### DIFF
--- a/pages/metamask/main-page.js
+++ b/pages/metamask/main-page.js
@@ -43,6 +43,11 @@ const addNetworkPage = {
 const options = {
   button: '[data-testid=account-options-menu-button]',
   accountDetailsButton: '[data-testid="account-options-menu__account-details"]',
+  connectedSitesButton: '[data-testid="account-options-menu__connected-sites"]',
+};
+
+const connectedSites = {
+  disconnectButton: '.connected-sites-list__trash',
 };
 
 const accountModal = {

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -4,6 +4,7 @@ require('dotenv').config()
 const helpers = require('../support/helpers')
 const puppeteer = require('../support/puppeteer');
 const metamask = require('../support/metamask');
+const { disconnectWallet } = require('../support/metamask');
 /**
  * @type {Cypress.PluginConfig}
  */
@@ -97,6 +98,10 @@ module.exports = (on, config) => {
       }
       const imported = await metamask.importWallet(secretWords, password);
       return imported;
+    },
+    async disconnectMetamaskWallet() {
+      await metamask.disconnectWallet();
+      return true
     },
     async importMetaMaskWalletUsingPrivateKey({ key }) {
       await puppeteer.switchToMetamaskWindow();

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -61,6 +61,10 @@ module.exports = (on, config) => {
       const assigned = await puppeteer.assignWindows();
       return assigned;
     },
+    clearWindows() {
+      puppeteer.clearWindows();
+      return true;
+    },
     async switchToCypressWindow() {
       const switched = await puppeteer.switchToCypressWindow();
       return switched;
@@ -100,7 +104,7 @@ module.exports = (on, config) => {
       await puppeteer.switchToMetamaskWindow();
       return imported
     },
-    
+
     async addMetamaskNetwork(network) {
       const networkAdded = await metamask.addNetwork(network);
       return networkAdded;

--- a/support/commands.js
+++ b/support/commands.js
@@ -18,6 +18,13 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'disconnectMetamaskWallet',
+  () => {
+    return cy.task('disconnectMetamaskWallet');
+  },
+);
+
+Cypress.Commands.add(
   'importMetaMaskWalletUsingPrivateKey',
   (key) => {
     return cy.task('importMetaMaskWalletUsingPrivateKey', { key });
@@ -88,4 +95,3 @@ Cypress.Commands.add(
   (number) => {
     return cy.task('changeAccount', { number })
   })
-

--- a/support/metamask.js
+++ b/support/metamask.js
@@ -95,9 +95,6 @@ module.exports = {
     }
     return true;
   },
-
-
-
   async changeNetwork(network) {
     setNetwork(network);
     await puppeteer.waitAndClick(mainPageElements.networkSwitcher.button);
@@ -293,4 +290,15 @@ module.exports = {
       return true;
     }
   },
+  async disconnectWallet() {
+    await puppeteer.switchToMetamaskWindow();
+
+    await puppeteer.waitAndClick(mainPageElements.options.button);
+    await puppeteer.waitAndClick(mainPageElements.options.connectedSitesButton);
+    await puppeteer.waitAndClick(mainPageElements.connectedSites.disconnectButton);
+    await puppeteer.waitAndClickByText('.btn-primary', 'Disconnect');
+
+    await puppeteer.switchToCypressWindow();
+    return true;
+  }
 };

--- a/support/puppeteer.js
+++ b/support/puppeteer.js
@@ -38,6 +38,10 @@ module.exports = {
     }
     return true;
   },
+  clearWindows() {
+    mainWindow = null;
+    metamaskWindow = null;
+  },
   async getBrowser() {
     return {
       puppeteerBrowser,


### PR DESCRIPTION
## Why?

The `before` action which sets up metamask is executed by cypress for
each new file, however the window state remains between runs. This
caused tests to hang on the unlock screen. By clearing the windows in
an `after` block the tests will appropriate unlock metamask and resume
the cypress test.

There is now also a task that will allow you to disconnect a wallet for
the cases you would like to undo connections between runs.

## Implemtation

Add a `clearWindows()` task that sets both windows to null.
add a `disconnectMetamaskWallet()` task to remove wallet connection to site.